### PR TITLE
Updated Hall of Fame link

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,6 +14,6 @@ This document outlines our security policy for the codebase, and how to report v
 
 If you think you have found a vulnerability, _please report responsibly_. Don't create GitHub issues for security issues. Instead, please send an email to `security@freecodecamp.org` and we'll look into it immediately.
 
-We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](HoF.md) list.
+We appreciate any responsible disclosure of vulnerabilities that might impact the integrity of our platforms and users. While we do not offer any bounties or swags at the moment, we'll be happy to list your name in our [Hall of Fame](https://contribute.freecodecamp.org/#/security-hall-of-fame) list.
 
 Ensure that you are using the **latest**, **stable** and **updated** version of the Operating System and Web Browser available to you on your machine.


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [ x ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [ x ] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

The current `SECURITY.md` policy (example [here](https://github.com/freeCodeCamp/.github/security/policy)) references a _Hall of Fame_ list that currently does not resolve correctly. Another reference to this _Hall of Fame_ was found on the core [freeCodeCamp repository on Github](https://github.com/freeCodeCamp/freeCodeCamp#reporting-security-issues-and-responsible-disclosure), which leads to the _Responsible Disclosure - Hall of Fame_ on the [freeCodeCamp website](https://contribute.freecodecamp.org/#/security-hall-of-fame). 
This is the same link I'm suggesting changing to within this PR.

<!-- Feel free to add any additional description of changes below this line -->
