### PR TITLE
docs: Make PULL_REQUEST_TEMPLATE.md more descriptive

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,13 @@ Checklist:
 <!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
 
 - [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
-- [ ] My pull request has a descriptive title (not a vague title like `Update index.md`)
+- [ ] I have read [freeCodeCamp's guidelines for creating a Pull Request](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
+- [ ] My pull request has a descriptive title and is less than 30 characters. Good examples are: 
+  - `feat: add more tests to HTML and CSS challenges`
+  - `docs(i18n): Chinese translation of local setup`
+  - `fix(a11y): improved search bar contrast`
+  - `fix(api,client): prevent CORS errors on form submission`
+     
 
 <!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,6 @@ Checklist:
 - [ ] I have read [freeCodeCamp's guidelines for creating a Pull Request](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
 - [ ] My pull request has a descriptive title and is less than 30 characters. Good examples are: 
   - `feat: add more tests to HTML and CSS challenges`
-  - `docs(i18n): Chinese translation of local setup`
   - `fix(a11y): improved search bar contrast`
   - `fix(api,client): prevent CORS errors on form submission`
      

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -3,12 +3,7 @@ Checklist:
 <!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->
 
 - [ ] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
-- [ ] I have read [freeCodeCamp's guidelines for creating a Pull Request](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request).
-- [ ] My pull request has a descriptive title and is less than 30 characters. Good examples are: 
-  - `feat: add more tests to HTML and CSS challenges`
-  - `fix(a11y): improved search bar contrast`
-  - `fix(api,client): prevent CORS errors on form submission`
-     
+- [ ] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)
 
 <!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->
 


### PR DESCRIPTION
Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a descriptive title (not a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

<!-- Feel free to add any additional description of changes below this line -->

The PR template can be improved to more readily provide the important information for creating a PR that conforms to the [instructions for creating a PR](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request). This proposed changes focusses on two main areas:

1. Specifically call out the PR guidelines link in a separate tick box.
2. Provide further guidelines and examples of good PR titles.

I believe `1.` is important to do, as there are a lot of contribution docs to look through for various types of changes. But when it comes to PRs, there's a specific page that applies to all changes, and so is best to ensure this is not missed.
`2.` is to bring clarity after recent discussion over previous PRs (#3, #4 and #5) and avoid wasted time for contributors and maintainers.
